### PR TITLE
Apply matchFilter naming and extend matching functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A router lets you change your view based on the URL in the browser. This allows your "single-page" application to simulate a traditional multipage site. To use Solid Router, you specify components called Routes that depend on the value of the URL (the "path"), and the router handles the mechanism of swapping them in and out.
 
-Solid Router is a universal router for SolidJS - it works whether you're rendering on the client or on the server. It was inspired by and combines paradigms of React Router and the Ember Router. Routes can be defined directly in your app's template using JSX, but you can also pass your route configuration directly as an object. It also supports nested routing, so navigation can change a part of a component, rather than completely replacing it. 
+Solid Router is a universal router for SolidJS - it works whether you're rendering on the client or on the server. It was inspired by and combines paradigms of React Router and the Ember Router. Routes can be defined directly in your app's template using JSX, but you can also pass your route configuration directly as an object. It also supports nested routing, so navigation can change a part of a component, rather than completely replacing it.
 
 It supports all of Solid's SSR methods and has Solid's transitions baked in, so use it freely with suspense, resources, and lazy components. Solid Router also allows you to define a data function that loads parallel to the routes ([render-as-you-fetch](https://epicreact.dev/render-as-you-fetch/)).
 
@@ -16,8 +16,8 @@ It supports all of Solid's SSR methods and has Solid's transitions baked in, so 
 - [Create Links to Your Routes](#create-links-to-your-routes)
 - [Dynamic Routes](#dynamic-routes)
 - [Data Functions](#data-functions)
-- [Nested Routes](#nested-routes) 
-- [Hash Mode Router](#hash-mode-router) 
+- [Nested Routes](#nested-routes)
+- [Hash Mode Router](#hash-mode-router)
 - [Config Based Routing](#config-based-routing)
 - [Router Primitives](#router-primitives)
   - [useParams](#useparams)
@@ -63,17 +63,16 @@ Solid Router allows you to configure your routes using JSX:
 
 1. Use the `Routes` component to specify where the routes should appear in your app.
 
-
 ```jsx
 import { Routes, Route } from "@solidjs/router"
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
+      <h1>My Site with Lots of Pages</h1>
     <Routes>
 
     </Routes>
-  </>
+    </>
 }
 ```
 
@@ -87,13 +86,13 @@ import Users from "./pages/Users"
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -109,13 +108,13 @@ const Home = lazy(() => import("./pages/Home"));
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -131,17 +130,17 @@ const Home = lazy(() => import("./pages/Home"));
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <nav>
-      <A href="/about">About</A>
-      <A href="/">Home</A>
-    </nav>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <nav>
+        <A href="/about">About</A>
+        <A href="/">Home</A>
+      </nav>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -163,7 +162,7 @@ Solid Router provides a `Navigate` component that works similarly to `A`, but it
 
 ```jsx
 function getPath ({navigate, location}) {
-  //navigate is the result of calling useNavigate(); location is the result of calling useLocation(). 
+  //navigate is the result of calling useNavigate(); location is the result of calling useLocation().
   //You can use those to dynamically determine a path to navigate to
   return "/some-path";
 }
@@ -174,7 +173,7 @@ function getPath ({navigate, location}) {
 
 ## Dynamic Routes
 
-If you don't know the path ahead of time, you might want to treat part of the path as a flexible parameter that is passed on to the component. 
+If you don't know the path ahead of time, you might want to treat part of the path as a flexible parameter that is passed on to the component.
 
 ```jsx
 import { lazy } from "solid-js";
@@ -185,14 +184,14 @@ const Home = lazy(() => import("./pages/Home"));
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/users/:id" component={User} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/users/:id" component={User} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -202,8 +201,8 @@ You can then access that `id` from within a route component with `useParams`:
 
 ---
 
-Each segment of the path can be validated using `SegmentValidator`.
-This allows for more complex routing descriptions than just checking the presence of a segment.
+Each path parameter can be validated using a `MatchFilter`.
+This allows for more complex routing descriptions than just checking the presence of a parameter.
 
 ```tsx
 import {lazy} from "solid-js";
@@ -214,30 +213,32 @@ const Users = lazy(() => import("./pages/Users"));
 const User = lazy(() => import("./pages/User"));
 const Home = lazy(() => import("./pages/Home"));
 
-const validators: SegmentValidators = {
-  id: (v: string) => /^\d+$/.test(v), // only allow numbers
-  withHtmlExtension: (v: string) => /\.html$/.test(v) // We want an `*.html` extension
+const filters: MatchFilters = {
+  parent: ['mom', 'dad'], // allow enum values
+  id: /^\d+$/, // only allow numbers
+  withHtmlExtension: (v: string) => v.length > 5 && v.endsWith('.html') // we want an `*.html` extension
 }
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users/:id/:withHtmlExtension" component={User} segmentValidators={validators}/>
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+      <Route path="/users/:parent/:id/:withHtmlExtension" component={User} matchFilters={filters}/>
+      </Routes>
+    </>
 }
 ```
 
-Here, we have added the `segmentValidators` prop. This allows us to validate the `id` and `withHtmlExtension` segments against the functions defined in `validators`.
+Here, we have added the `matchFilters` prop. This allows us to validate the `parent`, `id` and `withHtmlExtension` parameters against the filters defined in `filters`.
 If the validation fails, the route will not match.
 
 So in this example:
 
-- `/users/123/contact.html` would match,
-- `/users/123/about.html` would match,
-- `/users/me/contact.html` would not match `:id` is not a number,
-- `/users/123/contact` would not match `:withHtmlExtension` is missing `.html`.
+- `/users/mom/123/contact.html` would match,
+- `/users/dad/123/about.html` would match,
+- `/users/aunt/123/contact.html` would not match as `:parent` is not 'mom' or 'dad',
+- `/users/mom/me/contact.html` would not match as `:id` is not a number,
+- `/users/dad/123/contact` would not match as `:withHtmlExtension` is missing `.html`.
 
 ---
 
@@ -290,12 +291,10 @@ Routes also support defining multiple paths using an array. This allows a route 
 <Route path={["login", "register"]} component={Login}/>
 ```
 
-
 ## Data Functions
 In the [above example](#dynamic-routes), the User component is lazy-loaded and then the data is fetched. With route data functions, we can instead start fetching the data parallel to loading the route, so we can use the data as soon as possible.
 
-To do this, create a function that fetches and returns the data using `createResource`. Then pass that function to the `data` prop of the `Route` component. 
-
+To do this, create a function that fetches and returns the data using `createResource`. Then pass that function to the `data` prop of the `Route` component.
 
 ```js
 import { lazy } from "solid-js";
@@ -339,7 +338,7 @@ A common pattern is to export the data function that corresponds to a route in a
 ```js
 import { lazy } from "solid-js";
 import { Route } from "@solidjs/router";
-import { fetchUser } ... 
+import { fetchUser } ...
 import UserData from "./pages/users/[id].data.js";
 const User = lazy(() => import("/pages/users/[id].js"));
 
@@ -381,15 +380,14 @@ Only leaf Route nodes (innermost `Route` components) are given a route. If you w
 
 You can also take advantage of nesting by adding a parent element with an `<Outlet/>`.
 ```jsx
-
 import { Outlet } from "@solidjs/router";
 
 function PageWrapper () {
   return <div>
-    <h1> We love our users! </h1>
+      <h1> We love our users! </h1>
     <Outlet/>
-    <A href="/">Back Home</A>
-  </div>
+      <A href="/">Back Home</A>
+    </div>
 }
 
 <Route path="/users" component={PageWrapper}>
@@ -409,7 +407,7 @@ You can nest indefinitely - just remember that only leaf nodes will become their
 </Route>
 ```
 
-If you declare a `data` function on a parent and a child, the result of the parent's data function will be passed to the child's data function as the `data` property of the argument, as described in the last section. This works even if it isn't a direct child, because by default every route forwards its parent's data. 
+If you declare a `data` function on a parent and a child, the result of the parent's data function will be passed to the child's data function as the `data` property of the argument, as described in the last section. This works even if it isn't a direct child, because by default every route forwards its parent's data.
 
 ## Hash Mode Router
 
@@ -600,11 +598,9 @@ useBeforeLeave((e: BeforeLeaveEventArgs) => {
     setTimeout(() => {
       if (window.confirm("Discard unsaved changes - are you sure?")) {
         // user wants to proceed anyway so retry with force=true
-        e.retry(true); 
+        e.retry(true);
       }
     }, 100);
   }
 });
 ```
-
-

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -152,8 +152,8 @@ export const useRoutes = (routes: RouteDefinition | RouteDefinition[], base?: st
   return () => <Routes base={base}>{routes as any}</Routes>;
 };
 
-export type RouteProps<S extends string | readonly string[]> = {
-  path: S;
+export type RouteProps<S extends string> = {
+  path: S | S[];
   children?: JSX.Element;
   data?: RouteDataFunc;
   matchFilters?: MatchFilters<S>;
@@ -169,7 +169,7 @@ export type RouteProps<S extends string | readonly string[]> = {
     }
 );
 
-export const Route = <S extends string | readonly string[]>(props: RouteProps<S>) => {
+export const Route = <S extends string>(props: RouteProps<S>) => {
   const childRoutes = children(() => props.children);
   return mergeProps(props, {
     get children() {

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -21,12 +21,12 @@ import {
 import type {
   Location,
   LocationChangeSignal,
+  MatchFilters,
   Navigator,
   RouteContext,
   RouteDataFunc,
   RouteDefinition,
-  RouterIntegration,
-  SegmentValidators
+  RouterIntegration
 } from "./types";
 import { joinPaths, normalizePath } from "./utils";
 
@@ -152,11 +152,11 @@ export const useRoutes = (routes: RouteDefinition | RouteDefinition[], base?: st
   return () => <Routes base={base}>{routes as any}</Routes>;
 };
 
-export type RouteProps = {
-  path: string | string[];
+export type RouteProps<S extends string | readonly string[]> = {
+  path: S;
   children?: JSX.Element;
   data?: RouteDataFunc;
-  segmentValidators?: SegmentValidators;
+  matchFilters?: MatchFilters<S>;
 } & (
   | {
       element?: never;
@@ -169,7 +169,7 @@ export type RouteProps = {
     }
 );
 
-export const Route = (props: RouteProps) => {
+export const Route = <S extends string | readonly string[]>(props: RouteProps<S>) => {
   const childRoutes = children(() => props.children);
   return mergeProps(props, {
     get children() {
@@ -202,7 +202,14 @@ export interface AnchorProps extends Omit<JSX.AnchorHTMLAttributes<HTMLAnchorEle
 }
 export function A(props: AnchorProps) {
   props = mergeProps({ inactiveClass: "inactive", activeClass: "active" }, props);
-  const [, rest] = splitProps(props, ["href", "state", "class", "activeClass", "inactiveClass", "end"]);
+  const [, rest] = splitProps(props, [
+    "href",
+    "state",
+    "class",
+    "activeClass",
+    "inactiveClass",
+    "end"
+  ]);
   const to = useResolvedPath(() => props.href);
   const href = useHref(to);
   const location = useLocation();

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -21,6 +21,7 @@ import type {
   Location,
   LocationChange,
   LocationChangeSignal,
+  MatchFilters,
   NavigateOptions,
   Navigator,
   Params,
@@ -32,7 +33,6 @@ import type {
   RouterContext,
   RouterIntegration,
   RouterOutput,
-  SegmentValidators,
   SetParams
 } from "./types";
 import {
@@ -79,15 +79,15 @@ export const useNavigate = () => useRouter().navigatorFactory();
 export const useLocation = <S = unknown>() => useRouter().location as Location<S>;
 export const useIsRouting = () => useRouter().isRouting;
 
-export const useMatch = (path: () => string, segmentValidators?: SegmentValidators) => {
+export const useMatch = <S extends string>(path: () => S, matchFilters?: MatchFilters<S>) => {
   const location = useLocation();
   const matchers = createMemo(() =>
-    expandOptionals(path()).map((path) => createMatcher(path, undefined, segmentValidators))
+    expandOptionals(path()).map(path => createMatcher(path, undefined, matchFilters))
   );
   return createMemo(() => {
     for (const matcher of matchers()) {
-      const match = matcher(location.pathname)
-      if (match) return match
+      const match = matcher(location.pathname);
+      if (match) return match;
     }
   });
 };
@@ -105,13 +105,21 @@ export const useSearchParams = <T extends Params>(): [
   const navigate = useNavigate();
   const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(() => mergeSearchString(location.search, params));
-    navigate(location.pathname + searchString + location.hash, { scroll: false, resolve: false, ...options });
+    navigate(location.pathname + searchString + location.hash, {
+      scroll: false,
+      resolve: false,
+      ...options
+    });
   };
   return [location.query as T, setSearchParams];
 };
 
 export const useBeforeLeave = (listener: (e: BeforeLeaveEventArgs) => void) => {
-  const s = useRouter().beforeLeave.subscribe({ listener, location: useLocation(), navigate: useNavigate() });
+  const s = useRouter().beforeLeave.subscribe({
+    listener,
+    location: useLocation(),
+    navigate: useNavigate()
+  });
   onCleanup(s);
 };
 
@@ -128,11 +136,11 @@ export function createRoutes(
     element: component
       ? () => createComponent(component, {})
       : () => {
-        const { element } = routeDef;
-        return element === undefined && fallback
-          ? createComponent(fallback, {})
-          : (element as JSX.Element);
-      },
+          const { element } = routeDef;
+          return element === undefined && fallback
+            ? createComponent(fallback, {})
+            : (element as JSX.Element);
+        },
     preload: routeDef.component
       ? (component as MaybePreloadableComponent).preload
       : routeDef.preload,
@@ -147,7 +155,7 @@ export function createRoutes(
         ...shared,
         originalPath,
         pattern,
-        matcher: createMatcher(pattern, !isLeaf, routeDef.segmentValidators)
+        matcher: createMatcher(pattern, !isLeaf, routeDef.matchFilters)
       });
     }
     return acc;
@@ -195,7 +203,7 @@ export function createBranches(
       const routes = createRoutes(def, base, fallback);
       for (const route of routes) {
         stack.push(route);
-        const isEmptyArray = Array.isArray(def.children) && def.children.length === 0
+        const isEmptyArray = Array.isArray(def.children) && def.children.length === 0;
         if (def.children && !isEmptyArray) {
           createBranches(def.children, route.pattern, fallback, stack, branches);
         } else {
@@ -284,9 +292,9 @@ export function createRouterContext(
   const output =
     isServer && out
       ? (Object.assign(out, {
-        matches: [],
-        url: undefined
-      }) as RouterOutput)
+          matches: [],
+          url: undefined
+        }) as RouterOutput)
       : undefined;
 
   if (basePath === undefined) {

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -1,0 +1,112 @@
+import { RouteProps } from "../src/components";
+import { useMatch } from "../src/routing";
+import { MatchFilters } from "../src/types";
+import { createMatcher } from "../src/utils";
+
+// mock route type
+const Route = <S extends string | readonly string[]>(props: RouteProps<S>) => {};
+
+describe("Type checking on various route definitions", () => {
+  test("Does not check implementations", () => {});
+
+  // Matchfilters on createMatcher are typechecked
+  () => {
+    const _matcher = createMatcher("/:parent/:birthDate/*extras", undefined, {
+      parent: ["mom", "dad"],
+      birthDate: /^\d{4}$/,
+      extras: s => s.length > 4
+    });
+
+    const _invalid = createMatcher("/:unknown", undefined, {
+      // @ts-expect-error 'first' is not a path paramter
+      first: /^\d+$/
+    });
+
+    // allow disabling typechecks
+    const _asAny = createMatcher("/:unknown" as any, undefined, {
+      whatever: /^\d+$/
+    });
+  };
+
+  // Matchfilters on useMatch are typechecked
+  () => {
+    const _match = useMatch(() => "/:parent/:birthDate/*extras", {
+      parent: ["mom", "dad"],
+      birthDate: /^\d{4}$/,
+      extras: s => s.length > 4
+    });
+
+    const _invalid = useMatch(() => "/:unknown", {
+      // @ts-expect-error 'first' is not a path paramter
+      first: /^\d+$/
+    });
+
+    // allow disabling typechecks
+    const _asAny = useMatch("/:unknown" as any, {
+      whatever: /^\d+$/
+    });
+  };
+
+  // Matchfilters on a Route are typechecked
+  () => {
+    const _route = Route({
+      path: "/:parent/:birthDate/*extras",
+      matchFilters: {
+        parent: ["mom", "dad"],
+        birthDate: /^\d{4}$/,
+        extras: s => s.length > 4
+      }
+    });
+
+    const _invalid = Route({
+      path: "/:unknown",
+      matchFilters: {
+        // @ts-expect-error 'first' is not a path paramter
+        first: /^\d+$/
+      }
+    });
+
+    // allow disabling typechecks
+    const _asAny = Route({
+      path: "/:unknown" as any,
+      matchFilters: {
+        whatever: /^\d+$/
+      }
+    });
+
+    const _multiple = Route({
+      path: ["cars/:id", "vans/:id"],
+      matchFilters: {
+        id: /^\d+$/,
+        // TODO @ts-expect-error cannot infer bounded type for array paths
+        something: s => true,
+        // @ts-expect-error but does check MatchFilter
+        else: "invalid"
+      }
+    });
+
+    // cannot typecheck filters ahead of time, so 'any' is assumed
+    const matchFilters: MatchFilters = {
+      id: /^\d+$/,
+      other: s => s.length > 4
+    };
+
+    const _usingPredefined = Route({
+      path: "/:id",
+      matchFilters
+    });
+
+    // enable typechecking by specifying variables
+    const checkedMatchFilters: MatchFilters<":id"> = {
+      id: /^\d+$/,
+      // @ts-expect-error 'other' is not a defined paramter
+      other: s => s.length > 4
+    };
+
+    const _usingPredefinedTypesafe = Route({
+      path: "/:product",
+      // @ts-expect-error 'id' is not a defined paramter
+      checkedMatchFilters
+    });
+  };
+});

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -4,7 +4,7 @@ import { MatchFilters } from "../src/types";
 import { createMatcher } from "../src/utils";
 
 // mock route type
-const Route = <S extends string | readonly string[]>(props: RouteProps<S>) => {};
+const Route = <S extends string>(props: RouteProps<S>) => {};
 
 describe("Type checking on various route definitions", () => {
   test("Does not check implementations", () => {});
@@ -75,13 +75,12 @@ describe("Type checking on various route definitions", () => {
     });
 
     const _multiple = Route({
-      path: ["cars/:id", "vans/:id"],
+      path: ["cars/:id/:plate", "vans/:id"],
       matchFilters: {
         id: /^\d+$/,
-        // TODO @ts-expect-error cannot infer bounded type for array paths
-        something: s => true,
-        // @ts-expect-error but does check MatchFilter
-        else: "invalid"
+        plate: /^\d{2}-\w{3}-\d{2}$/,
+        // @ts-expect-error 'something' is not a parameter in either path
+        something: s => true
       }
     });
 


### PR DESCRIPTION
I implemented the functionality we discussed in [PR#227](https://github.com/solidjs/solid-router/pull/227). Also added a unit test for the added typechecks